### PR TITLE
Use the toLocaleDateString method

### DIFF
--- a/day-countdown.js
+++ b/day-countdown.js
@@ -94,7 +94,7 @@ class DayCountdown extends HTMLElement {
       if (now < then){
         this.config.phrase = "Days Remaining";
 	  }else if (then < now){
-		this.config.phrase = "Days since " + then.getDay() + '/' + then.getMonth() + '/' + then.getFullYear();
+		this.config.phrase = "Days since " + then.toLocaleDateString();
 	  }
     }
 


### PR DESCRIPTION
Fixes the bug in displaying the `Days Since xx/xx/xxxx:`. `getDay()` will return the day of the week (0 through 6) and `getMonth()` will return the month in the year (0 through 11). 

Instead we can use toLocaleDateString that will properly convert the `then` date variable to a string.